### PR TITLE
User player's nicknames in game if they have them

### DIFF
--- a/secret_hitler/config.py
+++ b/secret_hitler/config.py
@@ -1,5 +1,10 @@
 configuration = {
     # Only for testing
+    1: {
+       "roles": [
+           "Hitler"
+       ]
+    },
     2: {
        "roles": [
            "Liberal",

--- a/secret_hitler/game.py
+++ b/secret_hitler/game.py
@@ -5,10 +5,12 @@ from secret_hitler import config
 
 
 class Player:
-    def __init__(self, player_id):
+    def __init__(self, player_id, display_name, avatar_url):
         self.player_id = player_id
         self.role = None
         self.dead = False
+        self.display_name = display_name
+        self.avatar_url = avatar_url
 
     def get_id(self):
         return self.player_id
@@ -50,13 +52,12 @@ class Game:
         self.players = []
         self.dead = []
         self.state = GameStates.GAME_STARTING
-        self.add_player(admin_id)
         self.votes = {}
 
-    def add_player(self, player_id):
+    def add_player(self, player_id, display_name, avatar_url):
         if len(self.players) == self.max_players:
             return False
-        self.players.append(Player(player_id))
+        self.players.append(Player(player_id, display_name, avatar_url))
         return True
 
     def start_game(self):


### PR DESCRIPTION
Resolves #23.

User nicknames are tied to a discord server, so they aren't available in all contexts of this bot (eg, direct messages).  To resolve that, we now cache the player's name (nickname) and avatar in the game data.  The cache is updated by events when a user changes their name or avatar.

All locations that display the player's name are updated to display the cached name.

A couple of testing enhancements were also added
 - allowing a 1 player game to be created
 - adding a generic runtest command to the bot that can be used to run different things within the environment (currently just used to print what user data different objects have access to)
