### PR TITLE
Add permission verification during setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,2 +1,5 @@
+import secret_hitler.app as app
+
+
 if __name__ == "__main__":
-    import secret_hitler.app
+    app.start_app()

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,9 +1,65 @@
 import unittest
+import asyncio
+import logging
+from unittest.mock import Mock, MagicMock
+from discord.ext import commands
+import discord
+from secret_hitler import app
+from secret_hitler import config
+
+# Disable logging during testing
+logging.disable()
 
 
-class DummyAppTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, True)
+class AsyncMock(unittest.mock.MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+def create_mock_named(name):
+    mock_named = Mock()
+    mock_named.name = name
+    return mock_named
+
+
+class SetupAppTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_guild = Mock()
+        self. mock_guild.emojis = map(create_mock_named, config.configuration["emoji"])
+
+        mock_category = Mock()
+        mock_category.name = config.configuration["category"]
+        mock_category.channels = map(create_mock_named, config.configuration["channels"])
+        self.mock_guild.categories = [mock_category]
+
+        self.mock_ctx = Mock()
+        self.mock_ctx.guild = self.mock_guild
+
+    def test_setup_missing_permissions(self):
+        mock_permissions = discord.Permissions()
+        mock_permissions.update(
+            manage_roles=True,
+            manage_emojis=True,
+            manage_channels=True,
+            send_messages=False
+        )
+        self.mock_guild.me = Mock()
+        self.mock_guild.me.guild_permissions = mock_permissions
+        setup_success = asyncio.get_event_loop().run_until_complete(app.setup(self.mock_guild))
+        self.assertFalse(setup_success)
+
+    def test_setup_success(self):
+        mock_permissions = discord.Permissions()
+        mock_permissions.update(
+            manage_roles=True,
+            manage_emojis=True,
+            manage_channels=True,
+            send_messages=True
+        )
+        self.mock_guild.me = Mock()
+        self.mock_guild.me.guild_permissions = mock_permissions
+        setup_success = asyncio.get_event_loop().run_until_complete(app.setup(self.mock_guild))
+        self.assertTrue(setup_success)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Finally getting back to this...

Based on our conversation before, instead of inserting exception handling around any call that could fail due to missing permissions, this PR adds a permission verification step during setup since if we succeed at setup, permissions should be valid until the bot is uninstalled and needs to be set up again.

I also copied over some of the refactoring I did before to get the app in a more unit testable state. There's a smattering of Python style changes as well, since PyCharm is doing some kind of PEP linting and giving me low level warnings about all kinds of things. I might make one big PEP style pass just to satisfy my pickiness.

This is part of addressing issue #4.